### PR TITLE
Fix Dependabot Auto-Merge permissions and add workflow_dispatch

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,7 @@ name: Dependabot Auto-Merge
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,12 @@
 name: Dependabot Auto-Merge
-
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   dependabot:
@@ -16,13 +18,11 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:


### PR DESCRIPTION
This PR contains the final fixes for the Dependabot automation:
- Added `actions: write` permission to fix approval and auto-merge failures.
- Added `workflow_dispatch` to allow manual triggering of the merge workflow.
- Ensured `--delete-branch` is used as requested.

These changes were made after the initial automation PR was merged and are necessary for the auto-merge workflow to function correctly.